### PR TITLE
feat(planos): cria página de assinatura de planos

### DIFF
--- a/Frontend/desenrola-next/src/app/planos/AssinarPlano.module.css
+++ b/Frontend/desenrola-next/src/app/planos/AssinarPlano.module.css
@@ -1,0 +1,282 @@
+/* src/app/planos/AssinarPlano.module.css */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 50px 20px;
+  background-color: #f8fcf8;
+  font-family: sans-serif;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 50px;
+  max-width: 750px;
+}
+
+.header h1 {
+  font-size: 2.8rem;
+  color: #2c5b2d;
+  margin-bottom: 1rem;
+}
+
+.header p {
+  font-size: 1.1rem;
+  color: #555;
+  line-height: 1.6;
+}
+
+.toggle {
+  display: inline-flex;
+  background-color: #e8f5e9;
+  border-radius: 50px;
+  padding: 5px;
+  margin-top: 25px;
+}
+
+.toggleButton {
+  background-color: transparent;
+  border: none;
+  padding: 10px 25px;
+  border-radius: 50px;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #333;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.toggleButton.active {
+  background-color: #4CAF50;
+  color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.discount {
+  background-color: #ff9800;
+  color: #fff;
+  padding: 3px 8px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  margin-left: 8px;
+}
+
+.plansGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 30px;
+  max-width: 1200px;
+  width: 100%;
+  margin-bottom: 60px;
+}
+
+.planCard {
+  background-color: #fff;
+  border-radius: 15px;
+  padding: 35px;
+  text-align: center;
+  box-shadow: 0 5px 25px rgba(0, 0, 0, 0.07);
+  border: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.planCard:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.planCard h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 15px;
+}
+
+.price {
+  margin-bottom: 20px;
+}
+
+.currency {
+  font-size: 1.5rem;
+  color: #333;
+  vertical-align: top;
+  margin-right: 2px;
+}
+
+.amount {
+  font-size: 3.5rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.period {
+  font-size: 1rem;
+  color: #777;
+}
+
+.description {
+  color: #666;
+  min-height: 40px;
+  margin-bottom: 30px;
+}
+
+.featuresList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 30px 0;
+  text-align: left;
+  flex-grow: 1;
+}
+
+.featuresList li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+  font-size: 1rem;
+  color: #444;
+}
+
+.checkIcon {
+  color: #4CAF50;
+  margin-right: 12px;
+  font-size: 1.4rem;
+}
+
+.xIcon {
+  color: #f44336;
+  margin-right: 12px;
+  font-size: 1.4rem;
+}
+
+.buttonPrimary, .buttonVip {
+  color: #fff;
+  padding: 15px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  margin-top: auto;
+}
+
+.buttonPrimary {
+  background-color: #43A047;
+}
+.buttonPrimary:hover {
+  background-color: #388E3C;
+}
+
+.vipCard {
+  border: 2px solid #4CAF50;
+  position: relative;
+}
+
+.mostPopular {
+  position: absolute;
+  top: -15px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #4CAF50;
+  color: #fff;
+  padding: 6px 18px;
+  border-radius: 50px;
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.vipCard h2, .vipCard .amount {
+  color: #4CAF50;
+}
+
+.buttonVip {
+  background-color: #4CAF50;
+  box-shadow: 0 4px 15px rgba(76, 175, 80, 0.4);
+}
+.buttonVip:hover {
+  background-color: #388E3C;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(76, 175, 80, 0.4);
+}
+
+.guaranteeBox {
+  background-color: #388E3C;
+  color: #fff;
+  padding: 40px;
+  border-radius: 15px;
+  text-align: center;
+  max-width: 900px;
+  width: 100%;
+  margin-bottom: 60px;
+}
+
+.guaranteeBox h3 {
+  font-size: 2rem;
+  margin-bottom: 15px;
+}
+
+.guaranteeBox p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.faqSection {
+  background-color: #fff;
+  border-radius: 15px;
+  padding: 40px;
+  max-width: 900px;
+  width: 100%;
+  box-shadow: 0 5px 25px rgba(0, 0, 0, 0.07);
+}
+
+.faqSection h2 {
+  font-size: 2rem;
+  color: #333;
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.faqItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 0;
+  border-bottom: 1px solid #e0e0e0;
+  cursor: pointer;
+}
+
+.faqItem:last-child {
+  border-bottom: none;
+}
+
+.faqItem h3 {
+  font-size: 1.1rem;
+  color: #444;
+  font-weight: 500;
+}
+
+.faqItem span {
+  font-size: 1.5rem;
+  color: #4CAF50;
+  transition: transform 0.3s ease;
+}
+
+.faqItem:hover span {
+  transform: rotate(90deg);
+}
+
+@media (max-width: 1024px) {
+  .plansGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .header h1 {
+    font-size: 2.2rem;
+  }
+}

--- a/Frontend/desenrola-next/src/app/planos/page.jsx
+++ b/Frontend/desenrola-next/src/app/planos/page.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import styles from './AssinarPlano.module.css';
+import { FiCheck, FiX } from 'react-icons/fi'; // Ícones para listas de funcionalidades
+
+/**
+ * @component Planos
+ * @description A página principal para exibir e selecionar os planos de assinatura.
+ * * Funcionalidades:
+ * - Exibe um cabeçalho com título e descrição da página.
+ * - Apresenta um seletor para planos Mensais ou Anuais.
+ * - Mostra três opções de planos (Normal, VIP, Master) em um grid.
+ * - Cada plano detalha seu preço, descrição e uma lista de funcionalidades.
+ * - Destaca o plano "VIP" como o mais popular.
+ * - Inclui uma seção de garantia e uma lista de Perguntas Frequentes (FAQ).
+ * * @returns {JSX.Element} O componente renderizado da página de planos.
+ */
+const Planos = () => {
+  // OBS: Os dados dos planos e FAQ estão estáticos (hardcoded) no JSX.
+  // No futuro, eles podem ser extraídos de um array de objetos e renderizados dinamicamente.
+
+  return (
+    <div className={styles.container}>
+      {/* Seção do Cabeçalho: Título, subtítulo e seletor de período */}
+      <div className={styles.header}>
+        <h1>Escolha o Plano Ideal para Você</h1>
+        <p>Encontre prestadores de confiança, solicite serviços com facilidade e tenha acesso a recursos exclusivos. Comece grátis e evolua quando precisar!</p>
+        <div className={styles.toggle}>
+          <button className={`${styles.toggleButton} ${styles.active}`}>Mensal</button>
+          <button className={styles.toggleButton}>Anual <span className={styles.discount}>-10%</span></button>
+        </div>
+      </div>
+
+      {/* Grid que segura os três cartões de plano */}
+      <div className={styles.plansGrid}>
+        
+        {/* Cartão do Plano Normal (Grátis) */}
+        <div className={styles.planCard}>
+          <h2>Normal</h2>
+          <div className={styles.price}>
+            <span className={styles.currency}>R$</span>
+            <span className={styles.amount}>0,00</span>
+            <span className={styles.period}>/grátis</span>
+          </div>
+          <p className={styles.description}>Perfeito para começar a usar o Desenrola</p>
+
+          <ul className={styles.featuresList}>
+            {/* Funcionalidades incluídas (ícone de check) */}
+            <li><FiCheck className={styles.checkIcon} /> Cadastro de serviços básicos</li>
+            <li><FiCheck className={styles.checkIcon} /> Perfil visível, mas sem destaque</li>
+            <li><FiCheck className={styles.checkIcon} /> Pode receber avaliações e usar feedback básico</li>
+            {/* Funcionalidades não incluídas (ícone de X) */}
+            <li><FiX className={styles.xIcon} /> Sem prioridade no catálogo</li>
+            <li><FiX className={styles.xIcon} /> Relatórios limitados</li>
+          </ul>
+          <button className={styles.buttonPrimary}>COMEÇAR GRÁTIS</button>
+        </div>
+
+        {/* Cartão do Plano VIP (Destaque de "Mais Popular") */}
+        <div className={`${styles.planCard} ${styles.vipCard}`}>
+          <div className={styles.mostPopular}>MAIS POPULAR</div>
+          <h2>VIP</h2>
+          <div className={styles.price}>
+            <span className={styles.currency}>R$</span>
+            <span className={styles.amount}>29,90</span>
+            <span className={styles.period}>/mês</span>
+          </div>
+          <p className={styles.description}>Ideal para prestadores que querem se destacar</p>
+
+          <ul className={styles.featuresList}>
+            <li><FiCheck className={styles.checkIcon} /> Serviços aparecem com prioridade média no catálogo</li>
+            <li><FiCheck className={styles.checkIcon} /> Perfil ganha selo VIP nas solicitações</li>
+            <li><FiCheck className={styles.checkIcon} /> Mais chances básicas (respostas, estatísticas como visualizações e cliques no perfil)</li>
+            <li><FiCheck className={styles.checkIcon} /> Suporte prioritário</li>
+            <li><FiX className={styles.xIcon} /> Relatórios completos</li>
+          </ul>
+          <button className={styles.buttonVip}>ASSINAR VIP</button>
+        </div>
+
+        {/* Cartão do Plano Master */}
+        <div className={styles.planCard}>
+          <h2>Master</h2>
+          <div className={styles.price}>
+            <span className={styles.currency}>R$</span>
+            <span className={styles.amount}>59,90</span>
+            <span className={styles.period}>/mês</span>
+          </div>
+          <p className={styles.description}>Para profissionais que querem dominar o mercado</p>
+
+          <ul className={styles.featuresList}>
+            <li><FiCheck className={styles.checkIcon} /> Máxima visibilidade (sempre no topo do catálogo)</li>
+            <li><FiCheck className={styles.checkIcon} /> Perfil com selo exclusivo (ex: filtros, destaque especial)</li>
+            <li><FiCheck className={styles.checkIcon} /> Relatórios completos (taxas, conversões, avaliações)</li>
+            <li><FiCheck className={styles.checkIcon} /> Suporte prioritário e gerente de conta dedicado</li>
+            <li><FiCheck className={styles.checkIcon} /> Acesso antecipado a novos recursos</li>
+          </ul>
+          <button className={styles.buttonPrimary}>ASSINAR MASTER</button>
+        </div>
+      </div>
+
+      {/* Seção da Garantia de 30 Dias */}
+      <div className={styles.guaranteeBox}>
+        <h3>Garantia de 30 Dias</h3>
+        <p>Não ficou satisfeito? Oferecemos reembolso total em até 30 dias. Experimente sem riscos e veja como o Desenrola pode transformar seu negócio!</p>
+      </div>
+
+      {/* Seção de Perguntas Frequentes (FAQ) */}
+      <div className={styles.faqSection}>
+        <h2>? Perguntas Frequentes</h2>
+        {/* Cada item do FAQ pode no futuro ter um estado para abrir/fechar a resposta */}
+        <div className={styles.faqItem}>
+          <h3>Posso cancelar a qualquer momento?</h3>
+          <span>+</span>
+        </div>
+        <div className={styles.faqItem}>
+          <h3>Como funciona o teste gratuito?</h3>
+          <span>+</span>
+        </div>
+        <div className={styles.faqItem}>
+          <h3>Posso mudar de plano depois?</h3>
+          <span>+</span>
+        </div>
+        <div className={styles.faqItem}>
+          <h3>Quais formas de pagamento vocês aceitam?</h3>
+          <span>+</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Planos;


### PR DESCRIPTION
Adiciona a rota `/planos` com a estrutura completa da página de seleção de planos de assinatura.

- Cria a estrutura JSX com os três tipos de planos: Normal, VIP e Master.
- Inclui a lista de funcionalidades para cada plano com ícones de status.
- Adiciona as seções de Garantia e Perguntas Frequentes (FAQ).
- Estiliza a página com CSS Modules para ser responsiva e fiel ao design.